### PR TITLE
Implementar sistema de fondo inicial de caja

### DIFF
--- a/debug_database.java
+++ b/debug_database.java
@@ -1,0 +1,122 @@
+import java.sql.*;
+
+public class debug_database {
+    public static void main(String[] args) {
+        try {
+            // Conectar a la base de datos HSQLDB
+            Class.forName("org.hsqldb.jdbc.JDBCDriver");
+            String dbURL = "jdbc:hsqldb:file:" + System.getProperty("user.home") + "/kriolopos/kriolopos;shutdown=true";
+            Connection conn = DriverManager.getConnection(dbURL, "SA", "");
+            
+            System.out.println("✅ Conectado a la base de datos: " + dbURL);
+            
+            // 1. Verificar estructura de la tabla closedcash
+            System.out.println("\n📋 ESTRUCTURA DE LA TABLA CLOSEDCASH:");
+            DatabaseMetaData meta = conn.getMetaData();
+            ResultSet columns = meta.getColumns(null, null, "CLOSEDCASH", null);
+            
+            while (columns.next()) {
+                String columnName = columns.getString("COLUMN_NAME");
+                String dataType = columns.getString("TYPE_NAME");
+                int size = columns.getInt("COLUMN_SIZE");
+                boolean nullable = columns.getBoolean("NULLABLE");
+                
+                System.out.println("  - " + columnName + " (" + dataType + 
+                    (size > 0 ? "(" + size + ")" : "") + 
+                    (nullable ? " NULL" : " NOT NULL") + ")");
+            }
+            columns.close();
+            
+            // 2. Verificar si existe la columna initial_amount específicamente
+            System.out.println("\n🔍 VERIFICANDO COLUMNA 'INITIAL_AMOUNT':");
+            try {
+                PreparedStatement stmt = conn.prepareStatement(
+                    "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS " +
+                    "WHERE TABLE_NAME = 'CLOSEDCASH' AND COLUMN_NAME = 'INITIAL_AMOUNT'"
+                );
+                ResultSet rs = stmt.executeQuery();
+                if (rs.next()) {
+                    System.out.println("✅ La columna 'INITIAL_AMOUNT' SÍ existe en la tabla");
+                } else {
+                    System.out.println("❌ La columna 'INITIAL_AMOUNT' NO existe en la tabla");
+                }
+                rs.close();
+                stmt.close();
+            } catch (Exception e) {
+                System.out.println("⚠️ Error verificando columna: " + e.getMessage());
+            }
+            
+            // 3. Consultar datos actuales de la tabla closedcash
+            System.out.println("\n📊 DATOS ACTUALES DE CLOSEDCASH:");
+            PreparedStatement queryStmt = conn.prepareStatement(
+                "SELECT MONEY, HOST, DATESTART, DATEEND, INITIAL_AMOUNT FROM CLOSEDCASH ORDER BY DATESTART DESC"
+            );
+            
+            ResultSet rs = queryStmt.executeQuery();
+            int count = 0;
+            
+            while (rs.next() && count < 5) {
+                String money = rs.getString("MONEY");
+                String host = rs.getString("HOST");
+                Timestamp dateStart = rs.getTimestamp("DATESTART");
+                Timestamp dateEnd = rs.getTimestamp("DATEEND");
+                
+                System.out.print("  [" + (count + 1) + "] MONEY: " + money + 
+                    ", HOST: " + host + 
+                    ", START: " + dateStart +
+                    ", END: " + dateEnd);
+                
+                try {
+                    double initialAmount = rs.getDouble("INITIAL_AMOUNT");
+                    boolean wasNull = rs.wasNull();
+                    
+                    if (wasNull) {
+                        System.out.println(", INITIAL_AMOUNT: NULL");
+                    } else {
+                        System.out.println(", INITIAL_AMOUNT: $" + initialAmount);
+                    }
+                } catch (SQLException e) {
+                    System.out.println(", INITIAL_AMOUNT: [COLUMNA NO EXISTE] - " + e.getMessage());
+                }
+                
+                count++;
+            }
+            
+            rs.close();
+            queryStmt.close();
+            
+            // 4. Intentar una consulta SELECT específica para initial_amount
+            System.out.println("\n🎯 PRUEBA CONSULTA ESPECÍFICA:");
+            try {
+                PreparedStatement testStmt = conn.prepareStatement(
+                    "SELECT MONEY, INITIAL_AMOUNT FROM CLOSEDCASH WHERE HOST = 'DESKTOP-DFKGUKU' ORDER BY DATESTART DESC"
+                );
+                
+                ResultSet testRs = testStmt.executeQuery();
+                if (testRs.next()) {
+                    String money = testRs.getString("MONEY");
+                    double initialAmount = testRs.getDouble("INITIAL_AMOUNT");
+                    boolean wasNull = testRs.wasNull();
+                    
+                    System.out.println("  MONEY: " + money);
+                    System.out.println("  INITIAL_AMOUNT: " + (wasNull ? "NULL" : "$" + initialAmount));
+                    System.out.println("  wasNull(): " + wasNull);
+                } else {
+                    System.out.println("  ❌ No se encontraron registros");
+                }
+                
+                testRs.close();
+                testStmt.close();
+            } catch (SQLException e) {
+                System.out.println("  ❌ Error en consulta: " + e.getMessage());
+            }
+            
+            conn.close();
+            System.out.println("\n🔒 Conexión cerrada");
+            
+        } catch (Exception e) {
+            System.err.println("❌ Error: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}

--- a/kriolos-opos-app/src/main/java/com/openbravo/pos/forms/JDialogInitialCash.java
+++ b/kriolos-opos-app/src/main/java/com/openbravo/pos/forms/JDialogInitialCash.java
@@ -1,0 +1,171 @@
+/*
+ * Sebastian POS - Diálogo para ingresar fondo inicial de caja
+ * Creado para manejar el fondo inicial cuando se abre una nueva caja
+ */
+package com.openbravo.pos.forms;
+
+import com.openbravo.format.Formats;
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.SwingConstants;
+import javax.swing.WindowConstants;
+
+/**
+ * Diálogo para ingresar el fondo inicial de caja
+ * @author Sebastian
+ */
+public class JDialogInitialCash extends JDialog {
+    
+    private static final long serialVersionUID = 1L;
+    
+    private JTextField m_jInitialAmount;
+    private JButton m_jOK;
+    
+    private double initialAmount = 0.0;
+    private boolean accepted = false;
+    
+    public JDialogInitialCash(JFrame parent) {
+        super(parent, "💰 Fondo Inicial de Caja", true);
+        initComponents();
+        setLocationRelativeTo(parent);
+    }
+    
+    private void initComponents() {
+        setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+        setSize(400, 250);
+        setLayout(new BorderLayout());
+        
+        // Panel principal
+        JPanel mainPanel = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        
+        // Título
+        JLabel titleLabel = new JLabel("💰 Ingrese el Fondo Inicial de Caja");
+        titleLabel.setFont(new Font("Arial", Font.BOLD, 16));
+        titleLabel.setHorizontalAlignment(SwingConstants.CENTER);
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.gridwidth = 2;
+        gbc.insets = new Insets(20, 10, 10, 10);
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        mainPanel.add(titleLabel, gbc);
+        
+        // Descripción
+        JLabel descLabel = new JLabel("<html><center>Ingrese la cantidad de dinero que tiene<br>en la caja al iniciar el turno</center></html>");
+        descLabel.setHorizontalAlignment(SwingConstants.CENTER);
+        gbc.gridy = 1;
+        gbc.insets = new Insets(5, 10, 15, 10);
+        mainPanel.add(descLabel, gbc);
+        
+        // Label de cantidad
+        JLabel amountLabel = new JLabel("💵 Cantidad (MX$):");
+        amountLabel.setFont(new Font("Arial", Font.BOLD, 12));
+        gbc.gridwidth = 1;
+        gbc.gridx = 0;
+        gbc.gridy = 2;
+        gbc.insets = new Insets(5, 10, 5, 5);
+        gbc.anchor = GridBagConstraints.EAST;
+        gbc.fill = GridBagConstraints.NONE;
+        mainPanel.add(amountLabel, gbc);
+        
+        // Campo de texto para la cantidad
+        m_jInitialAmount = new JTextField(15);
+        m_jInitialAmount.setFont(new Font("Arial", Font.PLAIN, 14));
+        m_jInitialAmount.setText("0.00");
+        m_jInitialAmount.selectAll();
+        gbc.gridx = 1;
+        gbc.insets = new Insets(5, 5, 5, 10);
+        gbc.anchor = GridBagConstraints.WEST;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        mainPanel.add(m_jInitialAmount, gbc);
+        
+        add(mainPanel, BorderLayout.CENTER);
+        
+        // Panel de botones
+        JPanel buttonPanel = new JPanel(new FlowLayout());
+        
+        m_jOK = new JButton("✅ Confirmar Fondo Inicial");
+        m_jOK.setFont(new Font("Arial", Font.BOLD, 14));
+        m_jOK.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                acceptAction();
+            }
+        });
+        
+        buttonPanel.add(m_jOK);
+        
+        add(buttonPanel, BorderLayout.SOUTH);
+        
+        // Focus inicial
+        m_jInitialAmount.requestFocusInWindow();
+        
+        // Enter en el campo de texto activa OK
+        m_jInitialAmount.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                acceptAction();
+            }
+        });
+    }
+    
+    private void acceptAction() {
+        try {
+            String text = m_jInitialAmount.getText().trim();
+            if (text.isEmpty()) {
+                text = "0.00";
+            }
+            initialAmount = Formats.CURRENCY.parseValue(text);
+            if (initialAmount < 0) {
+                // No permitir montos negativos
+                m_jInitialAmount.setText("0.00");
+                m_jInitialAmount.selectAll();
+                return;
+            }
+            accepted = true;
+            dispose();
+        } catch (Exception e) {
+            // Error al parsear, mantener el valor en 0
+            m_jInitialAmount.setText("0.00");
+            m_jInitialAmount.selectAll();
+        }
+    }
+    
+    /**
+     * Obtiene la cantidad ingresada por el usuario
+     * @return la cantidad del fondo inicial, o 0.0 si se canceló
+     */
+    public double getInitialAmount() {
+        return initialAmount;
+    }
+    
+    /**
+     * Verifica si el usuario confirmó el diálogo
+     * @return true cuando se confirma el fondo inicial
+     */
+    public boolean isAccepted() {
+        return accepted;
+    }
+    
+    /**
+     * Establece una cantidad predeterminada
+     * @param amount la cantidad predeterminada
+     */
+    public void setInitialAmount(double amount) {
+        this.initialAmount = amount;
+        m_jInitialAmount.setText(Formats.CURRENCY.formatValue(amount));
+        m_jInitialAmount.selectAll();
+    }
+}

--- a/kriolos-opos-app/src/main/java/com/openbravo/pos/panels/JPanelCloseMoney.java
+++ b/kriolos-opos-app/src/main/java/com/openbravo/pos/panels/JPanelCloseMoney.java
@@ -176,6 +176,7 @@ public class JPanelCloseMoney extends JPanel implements JPanelView, BeanFactoryA
         
         m_jCount.setText(null);
         m_jCash.setText(null);
+        m_jInitialAmount.setText(null);
 
         m_jSales.setText(null);
         m_jSalesSubtotal.setText(null);
@@ -202,6 +203,43 @@ public class JPanelCloseMoney extends JPanel implements JPanelView, BeanFactoryA
             
             m_jCount.setText(m_PaymentsToClose.printPayments());
             m_jCash.setText(m_PaymentsToClose.printPaymentsTotal());
+            
+            // Obtener el monto inicial de la caja abierta
+            try {
+                String sequenceToFind = m_PaymentsToClose.printSequence();
+                if (sequenceToFind != null && !sequenceToFind.trim().isEmpty()) {
+                    s = m_App.getSession();
+                    con = s.getConnection();
+                    
+                    SQL = "SELECT INITIAL_AMOUNT FROM CLOSEDCASH WHERE HOST = ? AND MONEY = ? ORDER BY DATEEND DESC LIMIT 1";
+                    
+                    // Para HSQLDB cambiar LIMIT por TOP
+                    String sdbmanager = m_dlSystem.getDBVersion();
+                    if ("HSQL Database Engine".equals(sdbmanager)) {
+                        SQL = "SELECT TOP 1 INITIAL_AMOUNT FROM CLOSEDCASH WHERE HOST = ? AND MONEY = ? ORDER BY DATEEND DESC";
+                    }
+                    
+                    java.sql.PreparedStatement pstmt = con.prepareStatement(SQL);
+                    pstmt.setString(1, m_App.getProperties().getHost());
+                    pstmt.setString(2, sequenceToFind);
+                    
+                    ResultSet rsInitial = pstmt.executeQuery();
+                    if (rsInitial.next()) {
+                        double initialAmount = rsInitial.getDouble("INITIAL_AMOUNT");
+                        m_jInitialAmount.setText(Formats.CURRENCY.formatValue(initialAmount));
+                    } else {
+                        m_jInitialAmount.setText(Formats.CURRENCY.formatValue(0.0));
+                    }
+                    
+                    rsInitial.close();
+                    pstmt.close();
+                } else {
+                    m_jInitialAmount.setText(Formats.CURRENCY.formatValue(0.0));
+                }
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Error obteniendo monto inicial: " + e.getMessage(), e);
+                m_jInitialAmount.setText(Formats.CURRENCY.formatValue(0.0));
+            }
             
             m_jSales.setText(m_PaymentsToClose.printSales());
             m_jSalesSubtotal.setText(m_PaymentsToClose.printSalesBase());
@@ -311,7 +349,7 @@ public class JPanelCloseMoney extends JPanel implements JPanelView, BeanFactoryA
                         m_App.getProperties().getHost(), 
                         m_App.getActiveCashSequence(), 
                         m_App.getActiveCashDateStart(), 
-                        m_App.getActiveCashDateEnd(),0});
+                        m_App.getActiveCashDateEnd(),0.0});
 
                 m_dlSystem.execDrawerOpened(
                     new Object[] {m_App.getAppUserView().getUser().getName(),"Close Cash"});
@@ -398,6 +436,8 @@ public class JPanelCloseMoney extends JPanel implements JPanelView, BeanFactoryA
         jLabel5 = new javax.swing.JLabel();
         m_jCash = new javax.swing.JTextField();
         jLabel4 = new javax.swing.JLabel();
+        m_jInitialAmount = new javax.swing.JTextField();
+        jLabelInitialAmount = new javax.swing.JLabel();
         m_jCount = new javax.swing.JTextField();
         m_jLinesRemoved = new javax.swing.JTextField();
         jLabel1 = new javax.swing.JLabel();
@@ -476,6 +516,17 @@ public class JPanelCloseMoney extends JPanel implements JPanelView, BeanFactoryA
         jLabel4.setText(AppLocal.getIntString("label.cash")); // NOI18N
         jLabel4.setPreferredSize(new java.awt.Dimension(150, 30));
         jPanel1.add(jLabel4, new org.netbeans.lib.awtextra.AbsoluteConstraints(350, 260, -1, -1));
+
+        m_jInitialAmount.setEditable(false);
+        m_jInitialAmount.setFont(new java.awt.Font("Arial", 0, 14)); // NOI18N
+        m_jInitialAmount.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        m_jInitialAmount.setPreferredSize(new java.awt.Dimension(150, 30));
+        jPanel1.add(m_jInitialAmount, new org.netbeans.lib.awtextra.AbsoluteConstraints(510, 230, -1, -1));
+
+        jLabelInitialAmount.setFont(new java.awt.Font("Arial", 0, 14)); // NOI18N
+        jLabelInitialAmount.setText("💰 Fondo Inicial"); // NOI18N
+        jLabelInitialAmount.setPreferredSize(new java.awt.Dimension(150, 30));
+        jPanel1.add(jLabelInitialAmount, new org.netbeans.lib.awtextra.AbsoluteConstraints(350, 230, -1, -1));
 
         m_jCount.setEditable(false);
         m_jCount.setFont(new java.awt.Font("Arial", 0, 14)); // NOI18N
@@ -710,7 +761,7 @@ public class JPanelCloseMoney extends JPanel implements JPanelView, BeanFactoryA
                         m_App.getProperties().getHost(), 
                         m_App.getActiveCashSequence(), 
                         m_App.getActiveCashDateStart(), 
-                        m_App.getActiveCashDateEnd(),0});
+                        m_App.getActiveCashDateEnd(),0.0});
 
                 m_dlSystem.execDrawerOpened(
                     new Object[] {m_App.getAppUserView().getUser().getName(),"Close Cash"});
@@ -770,11 +821,13 @@ public class JPanelCloseMoney extends JPanel implements JPanelView, BeanFactoryA
     private javax.swing.JLabel jLabel7;
     private javax.swing.JLabel jLabel8;
     private javax.swing.JLabel jLabel9;
+    private javax.swing.JLabel jLabelInitialAmount;
     private javax.swing.JPanel jPanel1;
     private javax.swing.JSeparator jSeparator1;
     private javax.swing.JTextField m_jCash;
     private javax.swing.JButton m_jCloseCash;
     private javax.swing.JTextField m_jCount;
+    private javax.swing.JTextField m_jInitialAmount;
     private javax.swing.JTextField m_jLinesRemoved;
     private javax.swing.JTextField m_jMaxDate;
     private javax.swing.JTextField m_jMinDate;

--- a/kriolos-opos-app/src/main/java/com/openbravo/pos/panels/PaymentsModel.java
+++ b/kriolos-opos-app/src/main/java/com/openbravo/pos/panels/PaymentsModel.java
@@ -73,6 +73,9 @@ public class PaymentsModel {
     private Double m_dSalesTaxNet;
     private java.util.List<SalesLine> m_lsales;
 
+    // Sebastian - Fondo inicial de caja
+    private Double m_dInitialAmount;
+
     private final static String[] SALEHEADERS = {"label.taxcategory", "label.totaltax", "label.totalnet"};
 
     private PaymentsModel() {
@@ -111,6 +114,9 @@ public class PaymentsModel {
         p.m_lremovedlines = new ArrayList<>();
 
         p.m_lsales = new ArrayList<>();
+        
+        // Sebastian - Fondo inicial por defecto
+        p.m_dInitialAmount = 0.0;
 
         return p;
     }
@@ -131,6 +137,9 @@ public class PaymentsModel {
         p.m_iSeq = app.getActiveCashSequence();
         p.m_dDateStart = app.getActiveCashDateStart();
         p.m_dDateEnd = null;
+        
+        // Sebastian - Cargar fondo inicial de la caja activa
+        p.m_dInitialAmount = app.getActiveCashInitialAmount();
 
 // JG 9 Nov 12
         // Product category Sales
@@ -1119,5 +1128,50 @@ public class PaymentsModel {
         public void setNumberOfEntries(int numberOfEntries) {
             this.numberOfEntries = numberOfEntries;
         }
+    }
+    
+    // Sebastian - Métodos para manejar el fondo inicial
+    
+    /**
+     * Obtiene el fondo inicial de la caja
+     * @return el fondo inicial como Double
+     */
+    public Double getInitialAmount() {
+        return m_dInitialAmount != null ? m_dInitialAmount : 0.0;
+    }
+    
+    /**
+     * Formatea el fondo inicial para mostrar
+     * @return el fondo inicial formateado como String
+     */
+    public String printInitialAmount() {
+        return Formats.CURRENCY.formatValue(getInitialAmount());
+    }
+    
+    /**
+     * Calcula el total de efectivo incluyendo el fondo inicial
+     * Solo aplica para pagos en efectivo ("cash")
+     * @return el total de efectivo más el fondo inicial
+     */
+    public Double getCashTotalWithInitial() {
+        Double cashTotal = 0.0;
+        
+        // Buscar pagos en efectivo
+        for (PaymentsLine payment : m_lpayments) {
+            if ("cash".equals(payment.getType())) {
+                cashTotal += payment.getValue();
+            }
+        }
+        
+        // Agregar fondo inicial
+        return cashTotal + getInitialAmount();
+    }
+    
+    /**
+     * Formatea el total de efectivo con fondo inicial para mostrar
+     * @return el total de efectivo con fondo inicial formateado como String
+     */
+    public String printCashTotalWithInitial() {
+        return Formats.CURRENCY.formatValue(getCashTotalWithInitial());
     }
 }

--- a/kriolos-opos-app/src/main/resources/pos_liquidbase/db-changelog-v5_0.xml
+++ b/kriolos-opos-app/src/main/resources/pos_liquidbase/db-changelog-v5_0.xml
@@ -19,4 +19,13 @@
             </column>
         </createTable>
     </changeSet>
+    
+    <!-- Sebastian - Agregar columna initial_amount para manejar fondo inicial de caja -->
+    <changeSet author="sebastian (unicenta-pos)" id="20241004-01">
+        <addColumn tableName="closedcash">
+            <column name="initial_amount" type="DOUBLE" defaultValueNumeric="0.0">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/kriolos-opos-domain/src/main/java/com/openbravo/pos/forms/AppView.java
+++ b/kriolos-opos-domain/src/main/java/com/openbravo/pos/forms/AppView.java
@@ -44,10 +44,12 @@ public interface AppView {
      
     /*ActiveCash*/
     public void setActiveCash(String value, int iSeq, Date dStart, Date dEnd);
+    public void setActiveCash(String value, int iSeq, Date dStart, Date dEnd, double initialAmount); // Sebastian - Con fondo inicial
     public String getActiveCashIndex();
     public int getActiveCashSequence();
     public Date getActiveCashDateStart();
     public Date getActiveCashDateEnd();
+    public double getActiveCashInitialAmount(); // Sebastian - Fondo inicial
 
     /*ClosedCash*/
     public void setClosedCash(String value, int iSeq, Date dStart, Date dEnd);    

--- a/kriolos-opos-domain/src/main/java/com/openbravo/pos/forms/CashDrawer.java
+++ b/kriolos-opos-domain/src/main/java/com/openbravo/pos/forms/CashDrawer.java
@@ -28,6 +28,7 @@ public class CashDrawer {
     private int cashSequence;
     private Date cashDateStart;
     private Date cashDateEnd;
+    private double initialAmount;  // Sebastian - Fondo inicial de caja
 
     public String getCashIndex() {
         return cashIndex;
@@ -59,6 +60,15 @@ public class CashDrawer {
 
     public void setCashDateEnd(Date cashDateEnd) {
         this.cashDateEnd = cashDateEnd;
+    }
+
+    // Sebastian - Métodos para manejar el fondo inicial
+    public double getInitialAmount() {
+        return initialAmount;
+    }
+
+    public void setInitialAmount(double initialAmount) {
+        this.initialAmount = initialAmount;
     }
 
 }

--- a/sebastian-add-initial-amount.sql
+++ b/sebastian-add-initial-amount.sql
@@ -1,0 +1,12 @@
+-- Sebastian POS - Agregar campo de fondo inicial a closedcash
+-- Ejecutar este script para agregar la funcionalidad de fondo inicial
+
+-- Agregar campo initial_amount a la tabla closedcash
+ALTER TABLE closedcash 
+ADD COLUMN initial_amount DECIMAL(10,2) DEFAULT 0.00 NOT NULL;
+
+-- Comentario del campo
+-- COMMENT ON COLUMN closedcash.initial_amount IS 'Fondo inicial de caja en pesos mexicanos';
+
+-- Verificar que se agregó correctamente
+-- SELECT * FROM closedcash LIMIT 1;


### PR DESCRIPTION
- Agregar columna initial_amount a tabla closedcash
- Crear diálogo JDialogInitialCash para configurar monto inicial
- Modificar JRootApp para manejar fondo inicial correctamente
- Solo pedir fondo inicial en cajas nuevas o sin configurar
- Actualizar DataLogicSystem con métodos para guardar/recuperar monto inicial
- Arreglar problema de persistencia en HSQLDB eliminando SHUTDOWN COMPACT
- Mejorar interfaz PaymentsModel y JPanelCloseMoney
- Actualizar AppView y CashDrawer para soportar fondo inicial

Fixes: El sistema ya no pide fondo inicial en cada reinicio